### PR TITLE
Fix(RaceScene): Define width and height in createUI method

### DIFF
--- a/src/scenes/RaceScene.js
+++ b/src/scenes/RaceScene.js
@@ -321,6 +321,9 @@ export default class RaceScene extends Phaser.Scene {
     }
     
     createUI() {
+        const width = this.cameras.main.width;
+        const height = this.cameras.main.height;
+
         // Timer
         this.timerText = this.add.text(10, 10, 'Time: 0.00', {
             font: '18px Arial',


### PR DESCRIPTION
Resolves a ReferenceError in `RaceScene.createUI()` where `width` and `height` variables were used without being defined within the method's scope.

The fix adds the following declarations at the beginning of `createUI()`:
  `const width = this.cameras.main.width;`
  `const height = this.cameras.main.height;`

This ensures that these variables, necessary for positioning UI elements, are properly initialized using the scene's camera dimensions, preventing the game from freezing when transitioning to the RaceScene.