### PR TITLE
Feat(RaceScene): Extend effective race distance 10x, display as 25m

### DIFF
--- a/src/scenes/RaceScene.js
+++ b/src/scenes/RaceScene.js
@@ -13,13 +13,16 @@ export default class RaceScene extends Phaser.Scene {
     }
 
     create() {
-        const raceDistanceMeters = 25; // 25-meter race
-        const pixelsPerMeter = 100;    // Each meter is 100 pixels long
-        this.poolWorldLength = raceDistanceMeters * pixelsPerMeter; // Total scrollable length
+        this.displayedRaceDistanceMeters = 25;
+        const actualRaceDistanceFactor = 10; // Makes the race 10x longer
+        this.actualRaceDistanceMeters = this.displayedRaceDistanceMeters * actualRaceDistanceFactor;
 
-        // Make these available to swimmers
-        this.raceDistanceMeters = raceDistanceMeters;
-        this.pixelsPerMeter = pixelsPerMeter;
+        this.pixelsPerMeter = 100; // Pixels per one actual meter
+
+        // This is the property Swimmer.js currently uses for finish condition via this.scene.raceDistanceMeters
+        this.raceDistanceMeters = this.actualRaceDistanceMeters;
+
+        this.poolWorldLength = this.actualRaceDistanceMeters * this.pixelsPerMeter;
 
         const width = this.cameras.main.width;
         const height = this.cameras.main.height;
@@ -107,7 +110,7 @@ export default class RaceScene extends Phaser.Scene {
         // Halfway marker
         const halfwayY = this.poolWorldLength / 2;
         this.add.rectangle(width / 2, halfwayY, width, 2, 0xcccccc);
-        this.add.text(width / 2 + 10, halfwayY, `${this.raceDistanceMeters / 2}m`, {
+        this.add.text(width / 2 + 10, halfwayY, `${this.displayedRaceDistanceMeters / 2}m`, {
             font: '12px Arial',
             fill: '#ffffff',
             stroke: '#000000',


### PR DESCRIPTION
This commit modifies `RaceScene.js` to make the functional race distance 10 times longer (effectively 250m), while ensuring that all user-facing UI text continues to refer to the race as "25m".

Changes:
- In `RaceScene.create()`:
    - Introduced `this.displayedRaceDistanceMeters = 25;`
    - Calculated `this.actualRaceDistanceMeters` by multiplying `displayedRaceDistanceMeters` by a factor of 10.
    - `this.poolWorldLength` is now based on `this.actualRaceDistanceMeters` (e.g., 250m * 100 pixels/m = 25000 pixels).
    - The scene property `this.raceDistanceMeters` (used by Swimmer.js for finish condition) is set to `this.actualRaceDistanceMeters`.
- In `RaceScene.createPool()`:
    - The physical halfway marker is positioned at `this.poolWorldLength / 2`.
    - The text for the halfway marker now correctly displays `${this.displayedRaceDistanceMeters / 2}m` (i.e., "12.5m").
- Verified that `ResultsScene.js` continues to display the race event as "... - 25m" as this was hardcoded.

This change aims to slow down the overall perceived pace of the game by extending the race duration, without altering the nominal "25m" race identity presented to you. Swimmer speeds (pixels/sec) remain as per the previous speed reduction adjustments.