### PR TITLE
Feat: Halve race length and swimmer speeds

### DIFF
--- a/src/scenes/RaceScene.js
+++ b/src/scenes/RaceScene.js
@@ -14,7 +14,7 @@ export default class RaceScene extends Phaser.Scene {
 
     create() {
         this.displayedRaceDistanceMeters = 25;
-        const actualRaceDistanceFactor = 10; // Makes the race 10x longer
+        const actualRaceDistanceFactor = 5; // Makes the race 10x longer
         this.actualRaceDistanceMeters = this.displayedRaceDistanceMeters * actualRaceDistanceFactor;
 
         this.pixelsPerMeter = 100; // Pixels per one actual meter

--- a/src/sprites/Swimmer.js
+++ b/src/sprites/Swimmer.js
@@ -14,7 +14,7 @@ export default class Swimmer {
         this.speed = 0;
         this.baseSpeed = 70; // Further reduced from 80 to slow down player
         this.momentum = 0; // Current forward momentum
-        this.maxMomentum = 13; // Further reduced from 150 to cap maximum speed
+        this.maxMomentum = 6.5; // Further reduced from 150 to cap maximum speed
         this.momentumDecay = 4; // Increased from 30 for faster momentum loss
         this.lastStrokeTime = 0;
         this.strokeCount = 0;
@@ -268,7 +268,7 @@ export default class Swimmer {
         } else {
             // AI uses enhanced speed system - average 100 pixels/sec with stroke-specific adjustments
             const strokeMultiplier = this.getStrokeSpeedMultiplier();
-            this.speed = 10 * (this.aiSkill || 1.0) * strokeMultiplier;
+            this.speed = 5 * (this.aiSkill || 1.0) * strokeMultiplier;
         }
     }
     
@@ -656,16 +656,16 @@ export default class Swimmer {
         if (keyPressed === this.expectedNextKey) {
             // Correct alternation - add momentum
             wasCorrectKey = true;
-            momentumGain = 3; // Reduced from 40 to slow progression
+            momentumGain = 1.5; // Reduced from 40 to slow progression
             
             // Timing bonus for good rhythm (250-700ms for tighter timing window)
             if (this.strokeCount > 1) {
                 if (timeSinceLastStroke >= 250 && timeSinceLastStroke <= 700) {
-                    momentumGain += 1; // Reduced bonus from 10 to 5
+                    momentumGain += 0.5; // Reduced bonus from 10 to 5
                 } else if (timeSinceLastStroke < 250) {
                     momentumGain += 0; // Reduced bonus from 3 to 2
                 } else if (timeSinceLastStroke > 1000) {
-                    momentumGain -= 2; // Keep penalty the same
+                    momentumGain -= 1; // Keep penalty the same
                 }
             }
             


### PR DESCRIPTION
Reduces the effective race distance by half and proportionally reduces player and AI swimmer speeds.

Changes:
- Modified `src/scenes/RaceScene.js` to set `actualRaceDistanceFactor` to 5 (was 10), halving the `actualRaceDistanceMeters` from 250 to 125.
- Modified `src/sprites/Swimmer.js`:
    - Halved `maxMomentum` for players from 13 to 6.5.
    - Halved momentum gain values within the player's `stroke` method.
    - Halved the base speed factor for AI from 10 to 5 in their speed calculation.
- Reverted previous incorrect changes to `poolLength` and `baseSpeed` in `src/config/gameConfig.js` as they were not the effective variables.

The goal of these changes is to shorten the race duration while keeping the relative difficulty and race dynamics similar, as the speed reduction counteracts the length reduction.