### PR TITLE
Fix: Virtual keyboard not appearing on iOS for name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
 </head>
 <body>
     <div id="game-container"></div>
+    <input type="text" id="nameInput" style="display: none;">
     <script src="https://cdn.jsdelivr.net/npm/phaser@3.80.1/dist/phaser.min.js"></script>
     <script type="module" src="src/main.js"></script>
 </body>


### PR DESCRIPTION
This commit addresses an issue where the virtual keyboard would not appear on iOS devices when you were attempting to enter a player name in the MenuScene.

The fix involves the following changes:

1.  **index.html**: An HTML `<input type="text">` element (`id="nameInput"`) has been added. This element is hidden by default.
2.  **src/scenes/MenuScene.js**:
    *   On mobile devices (`this.isMobile === true`), when you interact with the name input area, the native HTML input element is now displayed and focused. This triggers the iOS virtual keyboard.
    *   Event listeners are attached to this HTML input to synchronize its value with the game's `playerName` variable and to handle submission (on 'blur' or Enter key).
    *   The existing Phaser-based keyboard input is maintained for non-mobile devices to ensure previous functionality remains unchanged.
    *   Logic has been added to show/hide the HTML input element and the Phaser text display appropriately, and to ensure player name is saved to localStorage.

These changes ensure that iOS users can now properly enter their names using the native virtual keyboard.